### PR TITLE
feat: nginx proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
+  nightly:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -83,5 +83,8 @@ workflows:
             branches:
               only:
                 - master
+    jobs:
+      - build
+  default:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             source ~/.bashrc
             nvm use 10
             node --version
-            bin/e2e generate -n e2enet -c 5
+            bin/e2e generate -n e2enet -c 4
       - run:
           name: Make scripts executable
           command: 'sudo chmod +x dist/e2enet/docker*'
@@ -67,11 +67,6 @@ jobs:
           command: |
             cat dist/e2enet/node3/output.log
             cat dist/e2enet/node3/errors.log
-      - run:
-          name: Output results - node4
-          command: |
-            cat dist/e2enet/node4/output.log
-            cat dist/e2enet/node4/errors.log
 
 workflows:
   version: 2

--- a/lib/config/docker/docker-init.sh
+++ b/lib/config/docker/docker-init.sh
@@ -1,4 +1,4 @@
-for rawdir in */;
+for rawdir in node*/;
   do
   nodeDir="$(echo $rawdir | sed -e 's;/;;g')";
   p2pPort="$(expr $(echo "$(echo "${nodeDir}" | sed 's/[^0-9]*//g') + 4000"))"
@@ -15,13 +15,13 @@ for rawdir in */;
 done
 for nodeNumber in {0..9}
   do
-  networkExists="$(docker network ls | grep ${nodeNumber}backend | wc -l)"
+  networkExists="$(docker network ls | grep node${nodeNumber}backend | wc -l)"
   if [ $networkExists = 1 ]
   then
-    echo "[Network configuration] Network ${nodeNumber}backend already exists !"
+    echo "[Network configuration] Network node${nodeNumber}backend already exists !"
   else
-    echo "[Network configuration] Creating network ${nodeNumber}backend"
-    docker network create -d overlay ${nodeNumber}backend --scope=swarm
+    echo "[Network configuration] Creating network node${nodeNumber}backend"
+    docker network create -d overlay node${nodeNumber}backend --scope=swarm
   fi
 done
 networkExists="$(docker network ls | grep nodes | wc -l)"

--- a/lib/config/docker/docker-init.sh
+++ b/lib/config/docker/docker-init.sh
@@ -12,13 +12,16 @@ for rawdir in */;
   sed -i "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet/docker-compose.yml;
   sed -i "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet/docker-compose.yml;
   sed -i "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet/docker-compose.yml;
-  networkExists="$(docker network ls | grep ${nodeDir}backend | wc -l)"
+done
+for nodeNumber in {0..9}
+  do
+  networkExists="$(docker network ls | grep ${nodeNumber}backend | wc -l)"
   if [ $networkExists = 1 ]
   then
-    echo "[Network configuration] Network ${nodeDir}backend already exists !"
+    echo "[Network configuration] Network ${nodeNumber}backend already exists !"
   else
-    echo "[Network configuration] Creating network ${nodeDir}backend"
-    docker network create -d overlay ${nodeDir}backend --scope=swarm
+    echo "[Network configuration] Creating network ${nodeNumber}backend"
+    docker network create -d overlay ${nodeNumber}backend --scope=swarm
   fi
 done
 networkExists="$(docker network ls | grep nodes | wc -l)"

--- a/lib/config/docker/docker-start.sh
+++ b/lib/config/docker/docker-start.sh
@@ -14,3 +14,7 @@ for rawdir in */;
   docker stack deploy -c docker-compose-stack.yml ${nodeDir}
   cd ../../..
 done
+# deploying nginx server (for proxying requests to the nodes)
+cd nginx
+docker stack deploy -c docker-compose.yml nginx
+cd ..

--- a/lib/config/docker/docker-start.sh
+++ b/lib/config/docker/docker-start.sh
@@ -1,4 +1,4 @@
-for rawdir in */;
+for rawdir in node*/;
   do
   nodeDir="$(echo $rawdir | sed -e 's;/;;g')";
   echo "[docker-compose build] Building ${nodeDir} ...";
@@ -6,7 +6,7 @@ for rawdir in */;
   docker-compose build
   cd ../../..
 done
-for rawdir in */;
+for rawdir in node*/;
   do
   nodeDir="$(echo $rawdir | sed -e 's;/;;g')";
   echo "[docker-compose stack] Deploying ${nodeDir} ...";

--- a/lib/config/nginx/docker-compose.yml
+++ b/lib/config/nginx/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3'
+services:
+  nginx: 
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - 4900:4900
+    networks:
+      node0backend:
+        aliases:
+          - nginx
+      node1backend:
+        aliases:
+          - nginx
+      node2backend:
+        aliases:
+          - nginx
+      node3backend:
+        aliases:
+          - nginx
+      node4backend:
+        aliases:
+          - nginx
+      node5backend:
+        aliases:
+          - nginx
+      node6backend:
+        aliases:
+          - nginx
+      node7backend:
+        aliases:
+          - nginx
+      node8backend:
+        aliases:
+          - nginx
+      node9backend:
+        aliases:
+          - nginx
+
+networks:
+  node0backend:
+    external:
+      name: node0backend
+  node1backend:
+    external:
+      name: node1backend
+  node2backend:
+    external:
+      name: node2backend
+  node3backend:
+    external:
+      name: node3backend
+  node4backend:
+    external:
+      name: node4backend
+  node5backend:
+    external:
+      name: node5backend
+  node6backend:
+    external:
+      name: node6backend
+  node7backend:
+    external:
+      name: node7backend
+  node8backend:
+    external:
+      name: node8backend
+  node9backend:
+    external:
+      name: node9backend
+  

--- a/lib/config/nginx/nginx.conf
+++ b/lib/config/nginx/nginx.conf
@@ -1,0 +1,13 @@
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+http {
+    server {
+      listen 4900;
+      
+      location ~ /node([0-9]+)(.*)$ {
+          resolver 127.0.0.11;
+          proxy_pass http://node$1:4003$2;
+      }
+  }
+}

--- a/lib/generate-files.js
+++ b/lib/generate-files.js
@@ -57,6 +57,17 @@ class GenerateManager {
   }
 
   createFiles() {
+    // nginx files (proxy for external api requests to the nodes)
+    const thisNginxPath = path.join(this.rootPath, 'lib/config/nginx')
+    const distNginxPath = path.join(this.rootPath, 'dist', this.network, 'nginx')
+    copyFiles([
+      {
+        from: thisNginxPath,
+        to: distNginxPath,
+        files: [ 'docker-compose.yml', 'nginx.conf' ]
+      }
+    ])
+
     const thisNetworkPath = path.join(this.rootPath, 'tests/networks', this.network)
     const thisDockerPath = path.join(this.rootPath, 'lib/config/docker')
 

--- a/lib/generate-files.js
+++ b/lib/generate-files.js
@@ -60,13 +60,19 @@ class GenerateManager {
     // nginx files (proxy for external api requests to the nodes)
     const thisNginxPath = path.join(this.rootPath, 'lib/config/nginx')
     const distNginxPath = path.join(this.rootPath, 'dist', this.network, 'nginx')
-    copyFiles([
-      {
-        from: thisNginxPath,
-        to: distNginxPath,
-        files: [ 'docker-compose.yml', 'nginx.conf' ]
+    fs.mkdir(distNginxPath, (err) => {
+      if (err) {
+         return console.error(err);
       }
-    ])
+      copyFiles([
+        {
+          from: thisNginxPath,
+          to: distNginxPath,
+          files: [ 'docker-compose.yml', 'nginx.conf' ]
+        }
+      ])
+      console.log(`[generate-files] Files copy done for nginx`);
+    })
 
     const thisNetworkPath = path.join(this.rootPath, 'tests/networks', this.network)
     const thisDockerPath = path.join(this.rootPath, 'lib/config/docker')

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -2,7 +2,7 @@
 
 const jest = require("jest")
 const delay = require("delay")
-const utils = require("./utils/test-utils")
+const testUtils = require("./utils/test-utils")
 const path = require('path')
 const fs = require('fs')
 
@@ -114,7 +114,7 @@ class TestRunner {
     
     let response
     try {
-      response = await utils.request('GET', 'node/status', { port: 4300 + Number(nodeNumber) })
+      response = await testUtils.GET('node/status', {}, nodeNumber)
     }
     catch (e) {}
     
@@ -140,7 +140,7 @@ class TestRunner {
 
     const configuredBlockHeights = Object.keys(configAllTests.events.newBlock)
 
-    const response = await utils.request('GET', 'blocks?limit=1')
+    const response = await testUtils.GET('blocks?limit=1')
     if(response.status !== 200) {
       throw 'Node is not responding'
     }

--- a/lib/utils/test-utils.js
+++ b/lib/utils/test-utils.js
@@ -6,9 +6,16 @@ axios.defaults.adapter = require('axios/lib/adapters/http')
 //const { client, transactionBuilder } = require('@arkecosystem/crypto')
 
 class Helpers {
-  request (method, path, params = {}) {
-    const port = params.port || 4300
-    const url = `http://localhost:${port}/api/v2/${path}` //TODO be able to request any node, not only node0
+  async GET(path, params = {}, nodeId = 0) {
+    return this.request('GET', path, params, nodeId)
+  }
+
+  async POST(path, params = {}, nodeId = 0) {
+    return this.request('POST', path, params, nodeId)
+  }
+
+  request (method, path, params = {}, nodeId = 0) {
+    const url = `http://127.0.0.1:4900/node${nodeId}/api/v2/${path}`
     const headers = { 'API-Version': 2 }
     const request = axios[method.toLowerCase()]
 

--- a/tests/scenarios/scenario1/doublespend1/0.transfer-new-wallet.action.js
+++ b/tests/scenarios/scenario1/doublespend1/0.transfer-new-wallet.action.js
@@ -4,6 +4,7 @@ const axios = require('axios')
 const { client, transactionBuilder } = require('@arkecosystem/crypto')
 const utils = require('./utils')
 const networkUtils = require('../../../networks/e2enet/utils')
+const testUtils = require('../../../../lib/utils/test-utils')
 
 /**
  * Creates a transaction to a new wallet
@@ -22,7 +23,7 @@ module.exports = async (options) => {
       .sign(networkUtils.genesisWallet.passphrase)
       .getStruct()
 
-    await axios.post('http://127.0.0.1:4300/api/v2/transactions', {
+    await testUtils.POST('transactions', {
       transactions: [transaction1]
     })
 }

--- a/tests/scenarios/scenario1/doublespend1/1.doublespend.action.js
+++ b/tests/scenarios/scenario1/doublespend1/1.doublespend.action.js
@@ -3,6 +3,7 @@
 const axios = require('axios')
 const { client, transactionBuilder } = require('@arkecosystem/crypto')
 const utils = require('./utils')
+const testUtils = require('../../../../lib/utils/test-utils')
 
 /**
  * Attempt to double spend
@@ -29,7 +30,7 @@ module.exports = async (options) => {
       .sign(utils.doubleSpendSender.passphrase)
       .getStruct()
 
-    await axios.post('http://127.0.0.1:4300/api/v2/transactions', {
+    await testUtils.POST('transactions', {
       transactions: [transaction1, transaction2]
     })
 }

--- a/tests/scenarios/scenario1/doublespend1/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend1/2.check-tx.test.js
@@ -5,7 +5,7 @@ const utils = require('./utils')
 
 describe('New wallet which was sent transaction', () => {
   it('should have coins in the wallet', async () => {
-    const response = await testUtils.request('GET', 'transactions')
+    const response = await testUtils.GET('transactions')
     testUtils.expectSuccessful(response)
     
     const transactions = response.data.data.filter(transaction => transaction.recipient === utils.doubleSpendRecipient.address)


### PR DESCRIPTION
Adds a nginx proxy connected with the docker swarm to each individual node constituting the network. Every request we want to make to any node now goes through this proxy, like this : 

- 127.0.0.1:4900/node0/api/..... will forward the request to "node0"
- 127.0.0.1:4900/node1/api/..... will forward the request to "node1"
- etc...

Before, every node was exposing its API through a global port (4300 for node0, 4301 for node1, etc) so that we could access it directly from our test framework. There are some issues with that when we want to disconnect / reconnect the nodes, hence the nginx proxy.

This nginx proxy is connected on docker to every node using its "backend" network, until now only used for communication with its postgres database. By doing this, we can disconnect any node from the global "nodes" network (the network for inter-nodes p2p communication), but still have an individual connection to each node because backend network is still connected.