### PR TITLE
test: add test doublespend-mix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,21 +55,21 @@ jobs:
             find ./dist/e2enet/node0/packages/ -name package.json -print0 | sort -z | xargs -r0
             echo ./dist/e2enet/node0/package.json | xargs md5sum | md5sum - > checksum.txt
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-0-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-0-0'
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-0-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-0-1'
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-1-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-1-0'
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-1-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-1-1'
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-2-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-2-0'
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-2-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-2-1'
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-3-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-3-0'
       - restore_cache:
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-3-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-3-1'
       - run:
           name: Make scripts executable
           command: 'sudo chmod +x dist/e2enet/docker*'
@@ -81,7 +81,7 @@ jobs:
           command: sudo bin/e2e run-tests -n e2enet -s scenario1
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-0-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-0-0'
           paths:
             - ./dist/e2enet/node0/packages/core/node_modules
             - ./dist/e2enet/node0/packages/core-api/node_modules
@@ -101,15 +101,8 @@ jobs:
             - ./dist/e2enet/node0/packages/core-http-utils/node_modules
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-0-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-0-1'
           paths:
-            - ./dist/e2enet/node0/packages/core-elasticsearch/node_modules
-            - ./dist/e2enet/node0/packages/core-error-tracker-bugsnag/node_modules
-            - ./dist/e2enet/node0/packages/core-error-tracker-sentry/node_modules
-            - ./dist/e2enet/node0/packages/core-event-emitter/node_modules
-            - ./dist/e2enet/node0/packages/core-forger/node_modules
-            - ./dist/e2enet/node0/packages/core-graphql/node_modules
-            - ./dist/e2enet/node0/packages/core-http-utils/node_modules
             - ./dist/e2enet/node0/packages/core-json-rpc/node_modules
             - ./dist/e2enet/node0/packages/core-logger/node_modules
             - ./dist/e2enet/node0/packages/core-logger-winston/node_modules
@@ -127,7 +120,7 @@ jobs:
             - ./dist/e2enet/node0/node_modules
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-1-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-1-0'
           paths:
             - ./dist/e2enet/node1/packages/core/node_modules
             - ./dist/e2enet/node1/packages/core-api/node_modules
@@ -147,15 +140,8 @@ jobs:
             - ./dist/e2enet/node1/packages/core-http-utils/node_modules
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-1-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-1-1'
           paths:
-            - ./dist/e2enet/node1/packages/core-elasticsearch/node_modules
-            - ./dist/e2enet/node1/packages/core-error-tracker-bugsnag/node_modules
-            - ./dist/e2enet/node1/packages/core-error-tracker-sentry/node_modules
-            - ./dist/e2enet/node1/packages/core-event-emitter/node_modules
-            - ./dist/e2enet/node1/packages/core-forger/node_modules
-            - ./dist/e2enet/node1/packages/core-graphql/node_modules
-            - ./dist/e2enet/node1/packages/core-http-utils/node_modules
             - ./dist/e2enet/node1/packages/core-json-rpc/node_modules
             - ./dist/e2enet/node1/packages/core-logger/node_modules
             - ./dist/e2enet/node1/packages/core-logger-winston/node_modules
@@ -173,7 +159,7 @@ jobs:
             - ./dist/e2enet/node1/node_modules
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-2-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-2-0'
           paths:
             - ./dist/e2enet/node2/packages/core/node_modules
             - ./dist/e2enet/node2/packages/core-api/node_modules
@@ -193,15 +179,8 @@ jobs:
             - ./dist/e2enet/node2/packages/core-http-utils/node_modules
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-2-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-2-1'
           paths:
-            - ./dist/e2enet/node2/packages/core-elasticsearch/node_modules
-            - ./dist/e2enet/node2/packages/core-error-tracker-bugsnag/node_modules
-            - ./dist/e2enet/node2/packages/core-error-tracker-sentry/node_modules
-            - ./dist/e2enet/node2/packages/core-event-emitter/node_modules
-            - ./dist/e2enet/node2/packages/core-forger/node_modules
-            - ./dist/e2enet/node2/packages/core-graphql/node_modules
-            - ./dist/e2enet/node2/packages/core-http-utils/node_modules
             - ./dist/e2enet/node2/packages/core-json-rpc/node_modules
             - ./dist/e2enet/node2/packages/core-logger/node_modules
             - ./dist/e2enet/node2/packages/core-logger-winston/node_modules
@@ -219,7 +198,7 @@ jobs:
             - ./dist/e2enet/node2/node_modules
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-3-0'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-3-0'
           paths:
             - ./dist/e2enet/node3/packages/core/node_modules
             - ./dist/e2enet/node3/packages/core-api/node_modules
@@ -239,15 +218,8 @@ jobs:
             - ./dist/e2enet/node3/packages/core-http-utils/node_modules
       - save_cache:
           when: always
-          key: 'core-e2e-{{ checksum "checksum.txt" }}-3-1'
+          key: 'core-e2e-0-{{ checksum "checksum.txt" }}-3-1'
           paths:
-            - ./dist/e2enet/node3/packages/core-elasticsearch/node_modules
-            - ./dist/e2enet/node3/packages/core-error-tracker-bugsnag/node_modules
-            - ./dist/e2enet/node3/packages/core-error-tracker-sentry/node_modules
-            - ./dist/e2enet/node3/packages/core-event-emitter/node_modules
-            - ./dist/e2enet/node3/packages/core-forger/node_modules
-            - ./dist/e2enet/node3/packages/core-graphql/node_modules
-            - ./dist/e2enet/node3/packages/core-http-utils/node_modules
             - ./dist/e2enet/node3/packages/core-json-rpc/node_modules
             - ./dist/e2enet/node3/packages/core-logger/node_modules
             - ./dist/e2enet/node3/packages/core-logger-winston/node_modules

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -37,7 +37,7 @@ class TestRunner {
   async runTests() {
     console.log('[test-runner] Waiting for node0 to be up on docker...')
     // wait for ark_node0 to be up + lerna.ok file to exist in dist/e2net/node0/
-    await this.waitForNode0Docker(900)
+    await this.waitForNodesDocker(900)
 
     // get the IP of all nodes to populate peers.json of each node
     console.log('[test-runner] Getting nodes info...')
@@ -102,15 +102,18 @@ class TestRunner {
     }
   }
 
-  async waitForNode0Docker(retryCount) {
-    if (retryCount === 0) throw 'Node 0 is not up on Docker'
+  async waitForNodesDocker(retryCount) {
+    if (retryCount === 0) throw 'Nodes are not up on Docker'
 
-    const commandNodeModuleExists = `ls ${this.rootPath}/dist/${this.network}/node0 | grep lerna.ok | wc -l`
-    const { stdout: stdoutNodeModuleExists, stderr: stderrNodeModuleExists } = await exec(commandNodeModuleExists)
-    
-    if (stdoutNodeModuleExists[0] !== '1') {
-      await delay(1000)
-      await this.waitForNode0Docker(--retryCount)
+    // check that the first 3 nodes are up, we assume that the others will be up too
+    for (let nodeNumber = 0; nodeNumber < 3; nodeNumber++) {
+      const commandNodeModuleExists = `ls ${this.rootPath}/dist/${this.network}/node${nodeNumber} | grep lerna.ok | wc -l`
+      const { stdout: stdoutNodeModuleExists, stderr: stderrNodeModuleExists } = await exec(commandNodeModuleExists)
+
+      if (stdoutNodeModuleExists[0] !== '1') {
+        await delay(1000)
+        return await this.waitForNodesDocker(--retryCount)
+      }
     }
   }
 

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -189,7 +189,8 @@ class TestRunner {
     const options = {
       projects: [__dirname],
       silent: true,
-      testPathPattern: ['tests\/scenarios\/' + this.scenario + '\/' + path.replace(/\//g,'\\/')]
+      testPathPattern: ['tests\/scenarios\/' + this.scenario + '\/' + path.replace(/\//g,'\\/')],
+      modulePathIgnorePatterns: ['dist\/']
     };
 
     jest

--- a/lib/utils/test-utils.js
+++ b/lib/utils/test-utils.js
@@ -11,6 +11,7 @@ class Helpers {
   }
 
   async POST(path, params = {}, nodeId = 0) {
+    console.log(`POST request body:  ${JSON.stringify(params, null, 2)}`)
     return this.request('POST', path, params, nodeId)
   }
 

--- a/tests/scenarios/scenario1/chained-tx/2.check-AtoB-forged.test.js
+++ b/tests/scenarios/scenario1/chained-tx/2.check-AtoB-forged.test.js
@@ -7,9 +7,12 @@ describe('Check confirmed and unconfirmed transactions', () => {
   it('should have no unconfirmed transaction', async () => {
     const response = await testUtils.GET('transactions/unconfirmed', {}, 1)
     testUtils.expectSuccessful(response)
-    const transactions = response.data.data
+    const transactions = response.data.data.filter(transaction =>
+      transaction.sender === utils.a.address ||
+      transaction.sender === utils.b.address
+    )
     
-    expect(transactions.length).toBe(0) // transaction was removed from pool
+    expect(transactions.length).toBe(0) // transactions were removed from pool
   })
 
   it('should have our 1st transaction forged only', async () => {
@@ -17,10 +20,10 @@ describe('Check confirmed and unconfirmed transactions', () => {
     testUtils.expectSuccessful(response)
     const transactions = response.data.data
 
-    const txToB = transactions.filter(transaction => transaction.recipient === utils.b.address)
-    const txToC = transactions.filter(transaction => transaction.recipient === utils.c.address)
+    const txAToB = transactions.filter(transaction => transaction.sender === utils.a.address)
+    const txBToC = transactions.filter(transaction => transaction.sender === utils.b.address)
     
-    expect(txToB.length).toBe(1) // 1st transaction was forged
-    expect(txToC.length).toBe(0) // 2nd transaction was not forged
+    expect(txAToB.length).toBe(1) // 1st transaction was forged
+    expect(txBToC.length).toBe(0) // 2nd transaction was not forged
   })
 })

--- a/tests/scenarios/scenario1/config.js
+++ b/tests/scenarios/scenario1/config.js
@@ -3,10 +3,10 @@
 module.exports = {
     network: 'e2enet',
     enabledTests: [
-        //'chained-tx',
-        //'doublespend',
+        'chained-tx',
+        'doublespend',
         'doublespend-mix',
-        //'insufficient-balance',
-        //'pool-restart'
+        'insufficient-balance',
+        'pool-restart'
     ]
 }

--- a/tests/scenarios/scenario1/config.js
+++ b/tests/scenarios/scenario1/config.js
@@ -3,9 +3,10 @@
 module.exports = {
     network: 'e2enet',
     enabledTests: [
-        'chained-tx',
-        'doublespend',
-        'insufficient-balance',
-        'pool-restart'
+        //'chained-tx',
+        //'doublespend',
+        'doublespend-mix',
+        //'insufficient-balance',
+        //'pool-restart'
     ]
 }

--- a/tests/scenarios/scenario1/doublespend-mix/0.0.transfer-new-wallet.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/0.0.transfer-new-wallet.action.js
@@ -32,7 +32,7 @@ module.exports = async (options) => {
             .getStruct(),
           transactionBuilder
             .transfer()
-            .amount(5 * Math.pow(10, 8) + transferAmount) // add 5 for 2nd sign registration fee
+            .amount(utils.fees.secondSignRegistration + transferAmount)
             .recipientId(wallets[2].address)
             .vendorField(`init double spend ${firstTxType} - ${secondTxType}`)
             .fee(0.1 * Math.pow(10, 8))

--- a/tests/scenarios/scenario1/doublespend-mix/0.0.transfer-new-wallet.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/0.0.transfer-new-wallet.action.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const { client, transactionBuilder } = require('@arkecosystem/crypto')
+const utils = require('./utils')
+const networkUtils = require('../../../networks/e2enet/utils')
+const testUtils = require('../../../../lib/utils/test-utils')
+
+/**
+ * Creates a transaction to a new wallet
+ * @param  {Object} options = { }
+ * @return {void}
+ */
+module.exports = async (options) => {
+    const config = require('../../../networks/e2enet/e2enet.json')
+    client.setConfig(config)
+
+    const transactions = []
+    Object.keys(utils.walletsMix).forEach((firstTxType) => {
+      const secondTxsTypes = utils.walletsMix[firstTxType]
+      
+      Object.keys(secondTxsTypes).forEach(secondTxType => {
+        const wallets = secondTxsTypes[secondTxType]
+        const transferAmount = _balanceNeededFromTxMix(firstTxType, secondTxType)
+        transactions.push(transactionBuilder
+          .transfer()
+          .amount(transferAmount)
+          .recipientId(wallets[0].address)
+          .vendorField(`init double spend ${firstTxType} - ${secondTxType}`)
+          .fee(0.1 * Math.pow(10, 8))
+          .sign(networkUtils.genesisWallet.passphrase)
+          .getStruct()
+        )
+      })
+    })
+
+    await testUtils.POST('transactions', { transactions })
+
+    function _balanceNeededFromTxMix(txType1, txType2) {
+      // we want to have 1 arkstoshi less than the amount needed for the 2 transactions
+      return utils.amountNeeded[txType1] + utils.amountNeeded[txType2] - 1
+    }
+}

--- a/tests/scenarios/scenario1/doublespend-mix/0.0.transfer-new-wallet.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/0.0.transfer-new-wallet.action.js
@@ -21,14 +21,23 @@ module.exports = async (options) => {
       Object.keys(secondTxsTypes).forEach(secondTxType => {
         const wallets = secondTxsTypes[secondTxType]
         const transferAmount = _balanceNeededFromTxMix(firstTxType, secondTxType)
-        transactions.push(transactionBuilder
-          .transfer()
-          .amount(transferAmount)
-          .recipientId(wallets[0].address)
-          .vendorField(`init double spend ${firstTxType} - ${secondTxType}`)
-          .fee(0.1 * Math.pow(10, 8))
-          .sign(networkUtils.genesisWallet.passphrase)
-          .getStruct()
+        transactions.push(
+          transactionBuilder
+            .transfer()
+            .amount(transferAmount)
+            .recipientId(wallets[0].address)
+            .vendorField(`init double spend ${firstTxType} - ${secondTxType}`)
+            .fee(0.1 * Math.pow(10, 8))
+            .sign(networkUtils.genesisWallet.passphrase)
+            .getStruct(),
+          transactionBuilder
+            .transfer()
+            .amount(5 * Math.pow(10, 8) + transferAmount) // add 5 for 2nd sign registration fee
+            .recipientId(wallets[2].address)
+            .vendorField(`init double spend ${firstTxType} - ${secondTxType}`)
+            .fee(0.1 * Math.pow(10, 8))
+            .sign(networkUtils.genesisWallet.passphrase)
+            .getStruct()
         )
       })
     })

--- a/tests/scenarios/scenario1/doublespend-mix/0.1.init-2ndsig.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/0.1.init-2ndsig.action.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { client, transactionBuilder } = require('@arkecosystem/crypto')
+const utils = require('./utils')
+const testUtils = require('../../../../lib/utils/test-utils')
+
+/**
+ * 2nd signature registration for double spend with 2nd signature
+ * @param  {Object} options = { }
+ * @return {void}
+ */
+module.exports = async (options) => {
+    const config = require('../../../networks/e2enet/e2enet.json')
+    client.setConfig(config)
+
+    /*const transactions = [
+      transactionBuilder
+        .secondSignature()
+        .signatureAsset(utils.doubleTransfer2ndsigSender2.passphrase)
+        .fee(5 * Math.pow(10, 8))
+        .sign(utils.doubleTransfer2ndsigSender.passphrase)
+        .getStruct()
+    ]
+
+    await testUtils.POST('transactions', { transactions })*/
+}

--- a/tests/scenarios/scenario1/doublespend-mix/0.1.init-2ndsig.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/0.1.init-2ndsig.action.js
@@ -22,7 +22,7 @@ module.exports = async (options) => {
         transactions.push(transactionBuilder
           .secondSignature()
           .signatureAsset(wallets[3].passphrase)
-          .fee(5 * Math.pow(10, 8))
+          .fee(utils.fees.secondSignRegistration)
           .sign(wallets[2].passphrase)
           .getStruct()
         )

--- a/tests/scenarios/scenario1/doublespend-mix/0.1.init-2ndsig.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/0.1.init-2ndsig.action.js
@@ -5,7 +5,7 @@ const utils = require('./utils')
 const testUtils = require('../../../../lib/utils/test-utils')
 
 /**
- * 2nd signature registration for double spend with 2nd signature
+ * Init 2nd signature wallets
  * @param  {Object} options = { }
  * @return {void}
  */
@@ -13,14 +13,21 @@ module.exports = async (options) => {
     const config = require('../../../networks/e2enet/e2enet.json')
     client.setConfig(config)
 
-    /*const transactions = [
-      transactionBuilder
-        .secondSignature()
-        .signatureAsset(utils.doubleTransfer2ndsigSender2.passphrase)
-        .fee(5 * Math.pow(10, 8))
-        .sign(utils.doubleTransfer2ndsigSender.passphrase)
-        .getStruct()
-    ]
+    const transactions = []
+    Object.keys(utils.walletsMix).forEach((firstTxType) => {
+      const secondTxsTypes = utils.walletsMix[firstTxType]
+      
+      Object.keys(secondTxsTypes).forEach(secondTxType => {
+        const wallets = secondTxsTypes[secondTxType]
+        transactions.push(transactionBuilder
+          .secondSignature()
+          .signatureAsset(wallets[3].passphrase)
+          .fee(5 * Math.pow(10, 8))
+          .sign(wallets[2].passphrase)
+          .getStruct()
+        )
+      })
+    })
 
-    await testUtils.POST('transactions', { transactions })*/
+    await testUtils.POST('transactions', { transactions })
 }

--- a/tests/scenarios/scenario1/doublespend-mix/1.0.doublespend.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/1.0.doublespend.action.js
@@ -59,7 +59,7 @@ module.exports = async (options) => {
       
       return transaction
         .fee(utils.fees[type])
-        .sign(wallets[0].address)
+        .sign(wallets[0].passphrase)
         .getStruct()
     }
 }

--- a/tests/scenarios/scenario1/doublespend-mix/1.0.doublespend.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/1.0.doublespend.action.js
@@ -53,7 +53,7 @@ module.exports = async (options) => {
         case 'delegateRegistration':
           transaction = transactionBuilder
             .delegateRegistration()
-            .usernameAsset(wallets[0].address.slice(0,10))
+            .usernameAsset(wallets[0].address.slice(0,10).toLowerCase())
           break;
       }
       

--- a/tests/scenarios/scenario1/doublespend-mix/1.0.doublespend.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/1.0.doublespend.action.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { client, transactionBuilder } = require('@arkecosystem/crypto')
+const utils = require('./utils')
+const testUtils = require('../../../../lib/utils/test-utils')
+const networkUtils = require('../../../networks/e2enet/utils')
+
+/**
+ * Attempt to double spend
+ * @param  {Object} options = { }
+ * @return {void}
+ */
+module.exports = async (options) => {
+    const config = require('../../../networks/e2enet/e2enet.json')
+    client.setConfig(config)
+
+    const transactions = []
+    Object.keys(utils.walletsMix).forEach((firstTxType) => {
+      const secondTxsTypes = utils.walletsMix[firstTxType]
+      
+      Object.keys(secondTxsTypes).forEach(secondTxType => {
+        const wallets = secondTxsTypes[secondTxType]
+        
+        transactions.push(
+          _genTransaction(firstTxType, wallets),
+          _genTransaction(secondTxType, wallets)
+        )
+        
+      })
+    })
+
+    await testUtils.POST('transactions', { transactions })
+
+    function _genTransaction(type, wallets) {
+      let transaction
+      switch (type) {
+        case 'transfer':
+          transaction = transactionBuilder
+            .transfer()
+            .amount(utils.transferAmount)
+            .recipientId(wallets[1].address)
+          break;
+        case 'vote':
+          transaction = transactionBuilder
+            .vote()
+            .votesAsset([`+${networkUtils.delegates[2].publicKey}`])
+          break;
+        case 'secondSignRegistration':
+          transaction = transactionBuilder
+            .secondSignature()
+            .signatureAsset(wallets[1].passphrase)
+          break;
+        case 'delegateRegistration':
+          transaction = transactionBuilder
+            .delegateRegistration()
+            .usernameAsset(wallets[0].address.slice(0,10))
+          break;
+      }
+      
+      return transaction
+        .fee(utils.fees[type])
+        .sign(wallets[0].address)
+        .getStruct()
+    }
+}

--- a/tests/scenarios/scenario1/doublespend-mix/1.1.doublespend2ndsig.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/1.1.doublespend2ndsig.action.js
@@ -3,6 +3,7 @@
 const { client, transactionBuilder } = require('@arkecosystem/crypto')
 const utils = require('./utils')
 const testUtils = require('../../../../lib/utils/test-utils')
+const networkUtils = require('../../../networks/e2enet/utils')
 
 /**
  * Attempt to double spend
@@ -13,6 +14,50 @@ module.exports = async (options) => {
     const config = require('../../../networks/e2enet/e2enet.json')
     client.setConfig(config)
 
+    const transactions = []
+    Object.keys(utils.walletsMix).forEach((firstTxType) => {
+      const secondTxsTypes = utils.walletsMix[firstTxType]
+      
+      Object.keys(secondTxsTypes).forEach(secondTxType => {
+        // ignore 2nd sign registration tx type as we already have a 2nd signature
+        if ([firstTxType, secondTxType].indexOf('secondSignRegistration') < 0) {
+          const wallets = secondTxsTypes[secondTxType]
+          
+          transactions.push(
+            _genTransaction(firstTxType, wallets),
+            _genTransaction(secondTxType, wallets)
+          )
+        }
+      })
+    })
 
-    //await testUtils.POST('transactions', { transactions })
+    await testUtils.POST('transactions', { transactions })
+
+    function _genTransaction(type, wallets) {
+      let transaction
+      switch (type) {
+        case 'transfer':
+          transaction = transactionBuilder
+            .transfer()
+            .amount(utils.transferAmount)
+            .recipientId(wallets[1].address)
+          break;
+        case 'vote':
+          transaction = transactionBuilder
+            .vote()
+            .votesAsset([`+${networkUtils.delegates[2].publicKey}`])
+          break;
+        case 'delegateRegistration':
+          transaction = transactionBuilder
+            .delegateRegistration()
+            .usernameAsset(wallets[2].address.slice(0,10).toLowerCase())
+          break;
+      }
+      
+      return transaction
+        .fee(utils.fees[type])
+        .sign(wallets[2].passphrase)
+        .secondSign(wallets[3].passphrase)
+        .getStruct()
+    }
 }

--- a/tests/scenarios/scenario1/doublespend-mix/1.1.doublespend2ndsig.action.js
+++ b/tests/scenarios/scenario1/doublespend-mix/1.1.doublespend2ndsig.action.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { client, transactionBuilder } = require('@arkecosystem/crypto')
+const utils = require('./utils')
+const testUtils = require('../../../../lib/utils/test-utils')
+
+/**
+ * Attempt to double spend
+ * @param  {Object} options = { }
+ * @return {void}
+ */
+module.exports = async (options) => {
+    const config = require('../../../networks/e2enet/e2enet.json')
+    client.setConfig(config)
+
+
+    //await testUtils.POST('transactions', { transactions })
+}

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -22,6 +22,6 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
       })
     })
 
-    expect(received).toEqual(response.data.data)
+    expect(received).toEqual(JSON.stringify(response.data.data, null, 2))
   })
 })

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -12,6 +12,7 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
       const secondTxsTypes = utils.walletsMix[firstTxType]
       
       Object.keys(secondTxsTypes).forEach(secondTxType => {
+        console.log(`test ${firstTxType} - ${secondTxType}`)
         const wallets = secondTxsTypes[secondTxType]
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -15,7 +15,10 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         const wallets = secondTxsTypes[secondTxType]
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
-        const txSent2ndSign = response.data.data.filter(tx => tx.sender === wallets[2].address)
+        const txSent2ndSign = response.data.data.filter(tx =>
+          tx.type !== 1 && // ignore the initial 2nd signature registration
+          tx.sender === wallets[2].address
+        )
 
         expect(txSent.length).toBe(1)
         expect(txSent2ndSign.length).toBe(1)

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const testUtils = require('../../../../lib/utils/test-utils')
+const utils = require('./utils')
+
+describe('Check that only 1 transaction out of the 2 was accepted', () => {
+  it('should have 1 transaction accepted', async () => {
+    const response = await testUtils.GET('transactions')
+    testUtils.expectSuccessful(response)
+    
+    Object.keys(utils.walletsMix).forEach((firstTxType) => {
+      const secondTxsTypes = utils.walletsMix[firstTxType]
+      
+      Object.keys(secondTxsTypes).forEach(secondTxType => {
+        const wallets = secondTxsTypes[secondTxType]
+        
+        const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
+        expect(txSent.length).toBe(1) // only 1 transaction was sent from this address
+      })
+    })
+
+  })
+})

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -16,9 +16,9 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
         const txSent2ndSign = response.data.data.filter(tx =>
-          tx.type !== 1 && // ignore the initial 2nd signature registration
           tx.sender === wallets[2].address
         )
+        expect(txSent2ndSign).toEqual({}) //debug
 
         expect(txSent.length).toBe(1)
         expect(txSent2ndSign.length).toBe(1)

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -8,17 +8,20 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
     const response = await testUtils.GET('transactions')
     testUtils.expectSuccessful(response)
     
+    const expected = {}
+    const received = {}
     Object.keys(utils.walletsMix).forEach((firstTxType) => {
       const secondTxsTypes = utils.walletsMix[firstTxType]
       
       Object.keys(secondTxsTypes).forEach(secondTxType => {
-        console.log(`test ${firstTxType} - ${secondTxType}`)
         const wallets = secondTxsTypes[secondTxType]
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
-        expect(txSent.length).toBe(1) // only 1 transaction was sent from this address
+        expected[`${firstTxType}-${secondTxType}`] = 1
+        received[`${firstTxType}-${secondTxType}`] = txSent.length
       })
     })
 
+    expect(received).toEqual(expected)
   })
 })

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -18,10 +18,10 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
         expected[`${firstTxType}-${secondTxType}`] = 1
-        received[`${firstTxType}-${secondTxType}`] = txSent.length
+        received[`${firstTxType}-${secondTxType}`] = wallets[0].address //txSent.length
       })
     })
 
-    expect(received).toEqual(expected)
+    expect(received).toEqual(response.data.data)
   })
 })

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -8,8 +8,6 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
     const response = await testUtils.GET('transactions')
     testUtils.expectSuccessful(response)
     
-    const expected = {}
-    const received = {}
     Object.keys(utils.walletsMix).forEach((firstTxType) => {
       const secondTxsTypes = utils.walletsMix[firstTxType]
       
@@ -17,8 +15,10 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         const wallets = secondTxsTypes[secondTxType]
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
+        const txSent2ndSign = response.data.data.filter(tx => tx.sender === wallets[2].address)
 
         expect(txSent.length).toBe(1)
+        expect(txSent2ndSign.length).toBe(1)
       })
     })
 

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -18,10 +18,10 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
         expected[`${firstTxType}-${secondTxType}`] = 1
-        received[`${firstTxType}-${secondTxType}`] = txSent.length
+        received[`${firstTxType}-${secondTxType}`] = wallets[0].address //txSent.length
       })
     })
 
-    expect(received).toEqual(expected)
+    expect(received).toEqual(JSON.stringify(response.data.data, null, 2))
   })
 })

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -15,15 +15,17 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         const wallets = secondTxsTypes[secondTxType]
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
-        const txSent2ndSign = response.data.data.filter(tx =>
-          tx.sender === wallets[2].address
-        )
-        expect(txSent2ndSign).toEqual({}) //debug
-
         expect(txSent.length).toBe(1)
-        expect(txSent2ndSign.length).toBe(1)
+
+        // ignore 2nd sign registration tx type - same as doublespend2ndsig.action
+        if ([firstTxType, secondTxType].indexOf('secondSignRegistration') < 0) {
+          const txSent2ndSign = response.data.data.filter(tx =>
+            tx.type !== 1 && // ignore the initial 2nd signature registration
+            tx.sender === wallets[2].address
+          )
+          expect(txSent2ndSign.length).toBe(1)
+        }
       })
     })
-
   })
 })

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -18,10 +18,10 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
         expected[`${firstTxType}-${secondTxType}`] = 1
-        received[`${firstTxType}-${secondTxType}`] = wallets[0].address //txSent.length
+        received[`${firstTxType}-${secondTxType}`] = txSent.length
       })
     })
 
-    expect(received).toEqual(JSON.stringify(response.data.data, null, 2))
+    expect(received).toEqual(expected)
   })
 })

--- a/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
+++ b/tests/scenarios/scenario1/doublespend-mix/2.check-tx.test.js
@@ -17,11 +17,10 @@ describe('Check that only 1 transaction out of the 2 was accepted', () => {
         const wallets = secondTxsTypes[secondTxType]
         
         const txSent = response.data.data.filter(tx => tx.sender === wallets[0].address)
-        expected[`${firstTxType}-${secondTxType}`] = 1
-        received[`${firstTxType}-${secondTxType}`] = wallets[0].address //txSent.length
+
+        expect(txSent.length).toBe(1)
       })
     })
 
-    expect(received).toEqual(JSON.stringify(response.data.data, null, 2))
   })
 })

--- a/tests/scenarios/scenario1/doublespend-mix/config.js
+++ b/tests/scenarios/scenario1/doublespend-mix/config.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+    events: {
+        newBlock: {
+            5: [ '0.0.transfer-new-wallet.action' ],
+            7: [ '0.1.init-2ndsig.action' ],
+            9: [ '1.0.doublespend.action',
+                  '1.1.doublespend2ndsig.action'
+                ],
+            12: [ '2.check-tx.test' ]
+        }
+    }
+}

--- a/tests/scenarios/scenario1/doublespend-mix/config.js
+++ b/tests/scenarios/scenario1/doublespend-mix/config.js
@@ -4,11 +4,11 @@ module.exports = {
     events: {
         newBlock: {
             5: [ '0.0.transfer-new-wallet.action' ],
-            7: [ '0.1.init-2ndsig.action' ],
-            9: [ '1.0.doublespend.action',
+            9: [ '0.1.init-2ndsig.action' ],
+            11: [ '1.0.doublespend.action',
                   '1.1.doublespend2ndsig.action'
                 ],
-            12: [ '2.check-tx.test' ]
+            14: [ '2.check-tx.test' ]
         }
     }
 }

--- a/tests/scenarios/scenario1/doublespend-mix/config.js
+++ b/tests/scenarios/scenario1/doublespend-mix/config.js
@@ -5,10 +5,10 @@ module.exports = {
         newBlock: {
             5: [ '0.0.transfer-new-wallet.action' ],
             9: [ '0.1.init-2ndsig.action' ],
-            11: [ '1.0.doublespend.action',
+            15: [ '1.0.doublespend.action',
                   '1.1.doublespend2ndsig.action'
                 ],
-            14: [ '2.check-tx.test' ]
+            20: [ '2.check-tx.test' ]
         }
     }
 }

--- a/tests/scenarios/scenario1/doublespend-mix/utils.js
+++ b/tests/scenarios/scenario1/doublespend-mix/utils.js
@@ -1,42 +1,276 @@
-const { client, crypto } = require('@arkecosystem/crypto')
-const bip39 = require('bip39')
-
-
-const genWallets = () => {
-  const config = require('../../../networks/e2enet/e2enet.json')
-  client.setConfig(config)
-
-  const wallets = []
-  for (let i = 0; i < 5; i++) {
-    const passphrase = bip39.generateMnemonic()
-    const keys = crypto.getKeys(passphrase)
-    const address = crypto.getAddress(keys.publicKey, config.pubKeyHash)
-    wallets.push({ passphrase, address })
-  }
-  
-  return wallets
-}
-
+// new wallets to be used for each double spend combination
 const walletsMix = {
   vote: {
-    delegateRegistration: genWallets(),
-    transfer: genWallets(),
-    secondSignRegistration: genWallets()
+    delegateRegistration: [
+      {
+        passphrase: "same electric inch favorite decide ripple clinic minute grab glove elevator morning",
+        address: "MJTKWXsZVH26WRQjRwJeF5ri9kBx4K3dFJ"
+      },
+      {
+        passphrase: "vintage attract spice swarm heavy square list high tank empty post defense",
+        address: "MQcigxHXG81jUQaKNRgLm6mVsRZWaUE6gq"
+      },
+      {
+        passphrase: "trap magnet eternal wreck sort room imitate original number edit manual aerobic",
+        address: "MDjDpmhG7WvVPKeqFSery2zEcNWm91T8qX"
+      },
+      {
+        passphrase: "civil gather rescue echo border convince mountain diamond allow online fit still",
+        address: "MUdx2FqtJJbLZDVUW6uJqD4J7Hn2rWQjVK"
+      },
+      {
+        passphrase: "space tennis mix damp client twenty island exhaust elder dolphin anger kid",
+        address: "M9bfX2QjNDtJXnAix7k2ipGfJNGid7Y8uQ"
+      }
+    ],
+    transfer: [
+      {
+        passphrase: "honey squirrel sentence pen length where roast much embark raise potato doll",
+        address: "M8ReMW7rxG12WXxBpFXvNe7NqJ7C4NLxZ5"
+      },
+      {
+        passphrase: "sock cradle original receive clay purse accuse recall stock remember artwork giraffe",
+        address: "MMZwhK8gnBrk7pzkpavCBqSds4jSdiBEkj"
+      },
+      {
+        passphrase: "pitch radio genuine nuclear mention bundle include usage bean tragic decrease common",
+        address: "MFq9Yddwi9vCWXvezwckrjscF8YpZyTSvG"
+      },
+      {
+        passphrase: "raw deny nice adult liar foster two census link deer matrix book",
+        address: "MGwkakADWgyhhCyqonr1RuamuxGoAuK9qY"
+      },
+      {
+        passphrase: "science place tribe beef limb ship voice finish mansion bonus prefer awful",
+        address: "MGNWGrJBsWZCp9CXkBY7j2rKDqMWWHEqt5"
+      }
+    ],
+    secondSignRegistration: [
+      {
+        passphrase: "reward item pull cannon cattle curtain wealth region concert require movie rude",
+        address: "MEtZSCdz42eUVjkpAazvTCVrwyW9WU26co"
+      },
+      {
+        passphrase: "drive ketchup select boost amount hand find blue angle antenna age erupt",
+        address: "MEQPSsw7U89fS6a5Hb3tT9Auk9jDWz7qhg"
+      },
+      {
+        passphrase: "celery coast skill trick boring master asthma dress fuel song divide absurd",
+        address: "MSqxxTQGTpVXWvrNUnAJj3J9PcAkUdwW8h"
+      },
+      {
+        passphrase: "cage else session whale ahead security idea inch virtual human whisper addict",
+        address: "MVp9DwGxYiP5SLaEpBEKi2rLCQD1UY2Edk"
+      },
+      {
+        passphrase: "polar achieve exhaust aisle cable crumble idea spike neck tilt course soccer",
+        address: "MLfJqNq8qVuwQUYB8eCAPSA59BcxJyiR5q"
+      }
+    ]
   },
   delegateRegistration: {
-    vote: genWallets(),
-    transfer: genWallets(),
-    secondSignRegistration: genWallets()
+    vote: [
+      {
+        passphrase: "choice snack warfare crush achieve universe salad camp unhappy ask strike orange",
+        address: "M9yU35jHZ8xP7Cqk6ngKSX1pxM4NDgjY4N"
+      },
+      {
+        passphrase: "shock grant horror across lesson hand upper travel hole question rich poet",
+        address: "MBLo14HgDNbYizhcBbnAUzjfKaLinYhsBR"
+      },
+      {
+        passphrase: "repair head diary pluck bulk mother lab deal amateur round release banner",
+        address: "MKk7d5PLBk1PYRvaBs2UeSUzAKYg28K1EE"
+      },
+      {
+        passphrase: "measure toward pipe hybrid toilet tonight path special minimum cannon chase decade",
+        address: "MDg7PkErYZ2AgTLLBcf9yTznU38AxDB7qd"
+      },
+      {
+        passphrase: "illness desert lunar old usage member report river prefer sample slight athlete",
+        address: "MTHvXgw6azXdtQpnqaBsr7o3cpioXub8Tb"
+      }
+    ],
+    transfer: [
+      {
+        passphrase: "lady cheese crisp analyst apart junior coyote tackle online together worry road",
+        address: "MUE6bUWwwM8pownH2EUQQLY1Drx5b7DP4z"
+      },
+      {
+        passphrase: "coconut spawn planet drill soft festival exercise tube video acid warfare lecture",
+        address: "MEkuKqThE8Yjmxv2L39pjgzuEMrQYdgJQh"
+      },
+      {
+        passphrase: "mean major bone frozen chuckle access obey plastic fall brain style crawl",
+        address: "MDYZwSgSV6BvMqv9Kf26MWtEXVB3wmj2VL"
+      },
+      {
+        passphrase: "hurdle enforce defense topple heart raccoon already tree tree sad asset place",
+        address: "MByNDv93EkBJmASRbT6FVSweAU96jp4DmE"
+      },
+      {
+        passphrase: "abandon silver situate happy only nothing arrest mention before smooth solve reason",
+        address: "MEspEHoPFbvRK9xRjSone4xwhEgjhojQJC"
+      }
+    ],
+    secondSignRegistration: [
+      {
+        passphrase: "flock square social critic gallery nominee display gift tank ready banana degree",
+        address: "MLXic3jgYbssTKqLVUaBnSpUurHiNdXaXF"
+      },
+      {
+        passphrase: "hammer inspire bronze lamp chunk wait maximum pottery jelly silent prosper lazy",
+        address: "MLcR3sSv1M52dd8KeKq4n8zmnCfMLzrhtR"
+      },
+      {
+        passphrase: "then payment degree wise antenna diamond modify tooth able silly remember taste",
+        address: "MB8HMemv6qZ8Z5pKA2TjKSYPf7Rk6AqNJm"
+      },
+      {
+        passphrase: "below rude anger help aunt master evil industry lock gossip toward reflect",
+        address: "MVGejUGD48L1wTrkjnLXofQdWEfwNCyat1"
+      },
+      {
+        passphrase: "you erosion symbol bamboo blouse bread journey discover moment chronic slogan section",
+        address: "MLASnnBT4JtFMok2fhRYMsGsXFXGceiFnB"
+      }
+    ]
   },
   transfer: {
-    vote: genWallets(),
-    delegateRegistration: genWallets(),
-    secondSignRegistration: genWallets()
+    vote: [
+      {
+        passphrase: "tower grow before valve index fever trip fee venue blood erase relief",
+        address: "MPvn5Ttzvjqk1uPqAkzXSSinD5MC8kMvDb"
+      },
+      {
+        passphrase: "lift museum educate only bonus into clarify field belt borrow page divorce",
+        address: "MCXGMvKZecwkkUrxEpWYrg2mP7jBfdVjUz"
+      },
+      {
+        passphrase: "marriage theme tilt episode spice hurry tomorrow small work drama mandate tape",
+        address: "MUAZkFLBYSUezXuJrtZRFjGXiNesjRwzs3"
+      },
+      {
+        passphrase: "furnace year van predict height drill question harsh ordinary joke patrol stay",
+        address: "M82R5Pn857CkuTGBK86kNpWUeMeDCezBJ6"
+      },
+      {
+        passphrase: "text cream pride merry soldier fall water defy slot dial motion mistake",
+        address: "MT8SkQb8Ef4nRzjkyMhEvY5nptr97B39jJ"
+      }
+    ],
+    delegateRegistration: [
+      {
+        passphrase: "ozone exist else estate naive catalog anxiety tell hole hockey idea hill",
+        address: "MLmB1Aoy4R649VXYEcNizNhB9EXG1wb4QE"
+      },
+      {
+        passphrase: "uncle rate rotate shock rose large spider captain person illegal hammer sure",
+        address: "MCa17heR8iBx3yZh4XKPiQQnq5TwjbGfNT"
+      },
+      {
+        passphrase: "mouse ignore pull retreat vague logic still zoo suggest burger push renew",
+        address: "MHavYpLyzoGR1TTFV6dHQZpHy2BtsdhjjG"
+      },
+      {
+        passphrase: "shield tag cup chalk cinnamon harvest vibrant mammal sing notice cargo victory",
+        address: "MKW2VPe6vp4KF5bAjM1tx7nx9Kb3AwKHXf"
+      },
+      {
+        passphrase: "lawsuit cousin tell gospel topple urban praise gallery junior face skate bless",
+        address: "M8W1kgf2Swc7zDWQAAZmbtVmND32TXWbVp"
+      }
+    ],
+    secondSignRegistration: [
+      {
+        passphrase: "grape circle joke face stairs record sign finger manage zero prevent kick",
+        address: "MGnnN3VNF2cZDzSZaQL1DVa6iddZimN9EE"
+      },
+      {
+        passphrase: "seat lava cancel coconut finish harsh pattern feature scheme tower remember lounge",
+        address: "MS8pY1ZqvFosMvLGyKEMuXeVjPFhLmxzX2"
+      },
+      {
+        passphrase: "sword current garbage choice slab gesture puppy build face fatigue filter door",
+        address: "MF98wtx9vvqG8kzxeu5CK23uVPX7Mwfna6"
+      },
+      {
+        passphrase: "gorilla sad final agree fabric wrestle rice quit ivory library rather puppy",
+        address: "MDrqmUyqrWdEyyGh5K2qof9UUgumM9Qbue"
+      },
+      {
+        passphrase: "blur quantum foil effort three educate manual toss image team delay brother",
+        address: "MRpDtE1WevfJ41J8mK57pjCm6f8YZsTwJ1"
+      }
+    ]
   },
   secondSignRegistration: {
-    vote: genWallets(),
-    delegateRegistration: genWallets(),
-    transfer: genWallets()
+    vote: [
+      {
+        passphrase: "genuine feel impact any melt lava atom couch manage define once beach",
+        address: "M93nxubhV9psvWftXnLkbXpDsuAFu8sTTY"
+      },
+      {
+        passphrase: "canyon organ slim palm age okay horse camp permit matrix empty airport",
+        address: "MJEBKb36kArDFTirnCAUr6YJ1Vt8ERTT1u"
+      },
+      {
+        passphrase: "marriage record convince arena reason flash slab trick trigger thank secret woman",
+        address: "MPu4VtwxeRYLwnKRAbxZhpC3WvHaZB3b2y"
+      },
+      {
+        passphrase: "prison firm comfort property broken story skate exchange jump patch giggle device",
+        address: "M8aCNBJUXnwYHn3ttP9nrCs7yC7RkmNfWk"
+      },
+      {
+        passphrase: "dwarf salmon glance raw venture try major deposit fruit rigid blast mushroom",
+        address: "M8aVpdpZnLm2oZ2vGo5sT8DN55VQuKnM9W"
+      }
+    ],
+    delegateRegistration: [
+      {
+        passphrase: "shiver child degree topple process fragile echo mind sail fuel machine fall",
+        address: "MMVVcfyktaDsMNiE24c8jVte5EUVj2Vz9D"
+      },
+      {
+        passphrase: "scorpion slot embrace traffic advice gentle pluck fossil super thing resource theory",
+        address: "M8NVA8quZ1vU9JJjo3x5C7t4ghPGfHaPKw"
+      },
+      {
+        passphrase: "dutch mask basic castle impulse impact tool yellow woman camera cute close",
+        address: "MJrHGJZv41JBhmTWP8cPseZk2gBQtnfyR3"
+      },
+      {
+        passphrase: "ring slab nothing damage dwarf citizen away coach cable fee silver net",
+        address: "MQQ4PE1i68UCLZy8QDr16kYMu861yndSFE"
+      },
+      {
+        passphrase: "blue cherry slice service where corn veteran zebra love iron blossom disease",
+        address: "MHTSWbA5h8QsbWgGcVKweAusExPVqb1GDJ"
+      }
+    ],
+    transfer: [
+      {
+        passphrase: "dance core deal brush rude social pride bomb proud effort cargo crouch",
+        address: "MSthcZ1ixKE4B6f2VjmxBo5TUo5P84y2hz"
+      },
+      {
+        passphrase: "maid major say relief page impact witness grow pulp spawn hen cook",
+        address: "M9PwYSwBpU4Ry4piQzyTXkgpMJQRbwnrZq"
+      },
+      {
+        passphrase: "network high rebuild accident scheme shoulder time hello evil diamond biology lecture",
+        address: "MPW16xQrM3yt8u6erQkDXwAq9oMQ9bhFfQ"
+      },
+      {
+        passphrase: "office angle rural train basket taxi float drop panther boil canal asset",
+        address: "MEuNDpc8q9V8czTaQeNRdo3bp9TRfCbCyz"
+      },
+      {
+        passphrase: "tape myself tortoise now clap ahead menu foot decorate sentence empty plug",
+        address: "MPbkaupeThFxr5ug5DZtAbHZeza8jq2vXR"
+      }
+    ]
   }
 }
 

--- a/tests/scenarios/scenario1/doublespend-mix/utils.js
+++ b/tests/scenarios/scenario1/doublespend-mix/utils.js
@@ -1,0 +1,64 @@
+const { client, crypto } = require('@arkecosystem/crypto')
+const bip39 = require('bip39')
+
+
+const genWallets = () => {
+  const config = require('../../../networks/e2enet/e2enet.json')
+  client.setConfig(config)
+
+  const wallets = []
+  for (let i = 0; i < 5; i++) {
+    const passphrase = bip39.generateMnemonic()
+    const keys = crypto.getKeys(passphrase)
+    const address = crypto.getAddress(keys.publicKey, config.pubKeyHash)
+    wallets.push({ passphrase, address })
+  }
+  
+  return wallets
+}
+
+const walletsMix = {
+  vote: {
+    delegateRegistration: genWallets(),
+    transfer: genWallets(),
+    secondSignRegistration: genWallets()
+  },
+  delegateRegistration: {
+    vote: genWallets(),
+    transfer: genWallets(),
+    secondSignRegistration: genWallets()
+  },
+  transfer: {
+    vote: genWallets(),
+    delegateRegistration: genWallets(),
+    secondSignRegistration: genWallets()
+  },
+  secondSignRegistration: {
+    vote: genWallets(),
+    delegateRegistration: genWallets(),
+    transfer: genWallets()
+  }
+}
+
+const arktoshi = 10 ** 8
+const transferAmount = 10 * arktoshi
+const amountNeeded = {
+  transfer: transferAmount + 0.1 * arktoshi,
+  vote: 1 * arktoshi,
+  secondSignRegistration: 5 * arktoshi,
+  delegateRegistration: 25 * arktoshi
+}
+
+const fees = {
+  transfer: 0.1 * arktoshi,
+  vote: 1 * arktoshi,
+  secondSignRegistration: 5 * arktoshi,
+  delegateRegistration: 25 * arktoshi
+}
+
+module.exports = {
+  walletsMix,
+  amountNeeded,
+  transferAmount,
+  fees
+}


### PR DESCRIPTION
New test doublespend-mix : try to double spend combining every possible transaction types.

We generate all possible 2-transactions combinations of different types : for example [transfer, vote] or [delegate registration, second signature registration].
But for each combination the sender wallet does not have enough funds to have them both accepted (1 arktoshi less in balance), so only 1 out of the 2 should be accepted.

"Simple" and second-signed transactions are tested.